### PR TITLE
added handler support

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -45,7 +45,7 @@ func ExampleSchema_Validate() {
 
 	// golibxml._Ctype_xmlDocPtr can't be cast to xsd.DocPtr, even though they are both
 	// essentially _Ctype_xmlDocPtr.  Using unsafe gets around this.
-	if err := xsdSchema.Validate(xsd.DocPtr(unsafe.Pointer(doc.Ptr))); err != nil {
+	if err := xsdSchema.Validate(xsd.DocPtr(unsafe.Pointer(doc.Ptr)), func(x string) { fmt.Printf("Message from handler #1: %s\n", x) }); err != nil {
 		fmt.Println(err)
 		return
 	}


### PR DESCRIPTION
I added handler support in a way that works for me. 

I'm not aggregating error messages, instead I provide handler to Validate method and let libxml to call it every time error occurs. I can do logging/aggregating all nasty stuff on application side as I wanted this to be as simple as possible.

every time I use validate I store handler in a map where context instance physical address is the key. when error occurs it will call back handler method which will find the application's handler based on context address and then it will invoke it. 

Stupidly simple but it matched my needs 
